### PR TITLE
Custom URL paths are no longer encoded

### DIFF
--- a/backbone.do.js
+++ b/backbone.do.js
@@ -102,7 +102,7 @@
     var base = _.result(model, 'url'),
         path = _.result(options, 'url') || Do.parseName(name),
         separator = base[base.length - 1] === '/' ? '' : '/';
-    options.url = base + separator + encodeURIComponent(path);
+    options.url = base + separator + path;
 
     // The contents request to the server will either be a key-value map of the specified
     // attributes, if any, or the merged `data` from the `action` and the current `options`.

--- a/test/tests.js
+++ b/test/tests.js
@@ -182,14 +182,14 @@
     equal(this.ajaxSettings.url, '/test/test1/action');
   });
 
-  test('custom URL paths are encoded', 4, function () {
+  test('custom URL paths are not encoded', 4, function () {
     var path = 'abcdefghijklmnopqrstuvwxyz0123456789!"£$%^&*()=+-_ `|\\,<.>/?;:\'@#~[{]}';
     doc.doAction({ url: path });
 
     strictEqual(this.syncArgs.model, doc);
     equal(this.syncArgs.method, 'create');
     equal(this.ajaxSettings.type, 'POST');
-    equal(this.ajaxSettings.url, '/test/test1/' + encodeURIComponent(path));
+    equal(this.ajaxSettings.url, '/test/test1/' + path);
   });
 
   test('pick attributes as string can be sent as data', 2, function () {


### PR DESCRIPTION
This was a poor general presumption and users can easily encode when
they want to while it's impossible to avoid encoding while we enforce it
