### PR TITLE
Cleaned API

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ Obviously, this plugin depends on [Backbone][] along with its dependencies.
 
 ### Actions
 
-Giving your model actions is as simple as adding a new hash and calling this plugin in your model's
-`initialize` function. `actions` can even be a function that returns a hash.
+Giving your model actions is as simple as adding a new hash and calling this plugin in your model's `initialize`
+function. `actions` can even be a function that returns a hash.
 
 ``` javascript
 var Book = Backbone.Model.extend({
@@ -56,9 +56,8 @@ var Book = Backbone.Model.extend({
 });
 ```
 
-Now the `Book` model has the 2 additional functions; `buy` and `getPages` which, when called, will
-result in a request being sent to the server based on their options as well as any options passed
-in.
+Now the `Book` model has the 2 additional functions; `buy` and `getPages` which, when called, will result in a request
+being sent to the server based on their options as well as any data and/or options passed in.
 
 ``` javascript
 var hobbit = new Book({
@@ -70,13 +69,13 @@ var hobbit = new Book({
   pageCount: 310
 });
 
-hobbit.buy().then(function () {
+hobbit.buy().then(function() {
   hobbit.getPages();
 });
 ```
 
-If the server returns an attribute hash, those values will then be applied to the model. In the
-previous example the following requests would have been sent to the server:
+If the server returns an attribute hash, those values will then be applied to the model. In the previous example the
+following requests would have been sent to the server:
 
 ```
 POST http://example.com/books/hobbit/buy
@@ -85,8 +84,8 @@ GET  http://example.com/books/hobbit/pages?pageCount=310
 
 The first request would have been sent the JSON-formatted data in the request body.
 
-Each action function accepts optional options that can overload the default configurations for
-that action.
+Each action function accepts optional data (to be sent to the server) and options (to configure the action) that can
+overload the defaults for that action.
 
 ``` javascript
 var ShoppingCart = Backbone.View.extend({
@@ -95,22 +94,20 @@ var ShoppingCart = Backbone.View.extend({
   },
 
   checkout: function() {
-    var data = {
+    this.model.buy({
       quantity: this.$('input.quantity-field').val()
-    };
-
-    this.model.buy({ data: data });
+    });
   }
 });
 ```
 
-There's a lot of ways in which actions can be declared so let's go over the different
-configurations. Each configuration can also be a function that returns the value to be used and all
-are entirely optional. Even the whole action can be a function that returns the configuration hash.
+There's a lot of ways in which actions can be declared so let's go over the different configurations. Each
+configuration can also be a function that returns the value to be used and all are entirely optional. Even the whole
+action can be a function that returns the configuration hash.
 
-Any other undocumented configurations will simply be passed along to [Backbone.sync][] and,
-eventually, [Backbone.ajax][] as options. Action functions also support the same asynchronous
-patterns as [Backbone.ajax][], whose result is also used as their return value.
+Any other undocumented configurations will simply be passed along to [Backbone.sync][] and, eventually,
+[Backbone.ajax][] as options. Action functions also support the same asynchronous patterns as [Backbone.ajax][], whose
+result is also used as their return value.
 
 #### `attrs`
 
@@ -146,8 +143,8 @@ Type(s): `Object`
 
 JSON-ifiable value that is to be sent to the server in the request body.
 
-**Note:** If the `attrs` configuration is used and no `data` is specified, the resulting attributes
-hash will replace the populate this value.
+**Note:** If the `attrs` configuration is used and no `data` is specified, the resulting attributes hash will replace
+the populate this value.
 
 ``` javascript
 var Book = Backbone.Model.extend({
@@ -171,8 +168,8 @@ var Book = Backbone.Model.extend({
 
 Type(s): `String`
 
-The HTTP method to be used in the request that is sent to the server. By default this is the value
-of [defaultMethod](#defaultmethod). This can be any of the following methods;
+The HTTP method to be used in the request that is sent to the server. By default this is the value of
+[defaultMethod](#defaultmethod). This can be any of the following methods;
 
 - `DELETE`
 - `GET`
@@ -184,16 +181,16 @@ of [defaultMethod](#defaultmethod). This can be any of the following methods;
 
 Type(s): `String`
 
-The path to be appended to URL of the model, which is used as the target of the server request. If
-this is not specified, the [parseName](#parsenamename) function will be called instead to derive
-an appropriate path based on the action's name.
+The path to be appended to URL of the model, which is used as the target of the server request. If this is not
+specified, the [parseName](#parsenamename) function will be called instead to derive an appropriate path based on the
+action's name.
 
 ### Miscellaneous
 
 #### `defaultMethod`
 
-The default HTTP method used by requests that don't specify one. This can be any of the same values
-for the [method](#method) configuration but, by default, is `POST`.
+The default HTTP method used by requests that don't specify one. This can be any of the same values for the
+[method](#method) configuration but, by default, is `POST`.
 
 ``` javascript
 Backbone.Do.defaultMethod = 'PUT';
@@ -203,13 +200,13 @@ Backbone.Do.defaultMethod = 'PUT';
 
 If an action doesn't specify a `url`, this function will be called to derive a path from it's name.
 
-By default, it simply returns the `name` with no modifications, but this allows you to customize
-this behaviour. For example; if you wanted actions with names in camel case to instead use hyphens
-you could use something like the following;
+By default, it simply returns the `name` with no modifications, but this allows you to customize this behaviour. For
+example; if you wanted actions with names in camel case to instead use hyphens you could use something like the
+following;
 
 ``` javascript
 Backbone.Do.parseName = function(name) {
-  return name.replace(/[A-Z]+/g, function (str) {
+  return name.replace(/[A-Z]+/g, function(str) {
     return '-' + str.toLowerCase();
   });
 };
@@ -232,8 +229,8 @@ Two different events will be trigger by this plugin:
 
 ## Bugs
 
-If you have any problems with this library or would like to see the changes currently in
-development you can do so here;
+If you have any problems with this library or would like to see the changes currently in development you can do so
+here;
 
 https://github.com/neocotic/Backbone.Do/issues
 
@@ -243,8 +240,7 @@ Take a look at `docs/backbone.do.html` to get a better understanding of what the
 
 If that doesn't help, feel free to follow me on Twitter, [@neocotic][].
 
-However, if you want more information or examples of using this library please visit the project's
-homepage;
+However, if you want more information or examples of using this library please visit the project's homepage;
 
 http://neocotic.com/Backbone.Do
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -110,6 +110,22 @@
     ok(!model.someAction);
   });
 
+  test('action names must not already exist on Model prototype', 1, function() {
+    var model;
+    var Model = Backbone.Model.extend({
+      actions: {
+        destroy: {}
+      },
+      initialize: function() {
+        Backbone.Do(this);
+      }
+    });
+
+    throws(function() {
+      model = new Model();
+    }, Error);
+  });
+
   test('actions can be a function', 1, function() {
     var Model = Backbone.Model.extend({
       actions: function() {
@@ -189,7 +205,7 @@
 
   test('custom URL paths are not encoded', 4, function() {
     var path = 'abcdefghijklmnopqrstuvwxyz0123456789!"£$%^&*()=+-_ `|\\,<.>/?;:\'@#~[{]}';
-    doc.doAction({ url: path });
+    doc.doAction(null, { url: path });
 
     strictEqual(this.syncArgs.model, doc);
     equal(this.syncArgs.method, 'create');
@@ -212,14 +228,14 @@
   });
 
   test('merged pick attributes as strings can be sent as data', 2, function() {
-    doc.doAction({ attrs: 'flag' });
+    doc.doAction(null, { attrs: 'flag' });
 
     strictEqual(this.syncArgs.model, doc);
     equal(this.ajaxSettings.data, JSON.stringify(doc.pick('number', 'string', 'flag')));
   });
 
   test('merged pick attributes in arrays can be sent as data', 2, function() {
-    doc.doAction({ attrs: [ 'flag' ] });
+    doc.doAction(null, { attrs: [ 'flag' ] });
 
     strictEqual(this.syncArgs.model, doc);
     equal(this.ajaxSettings.data, JSON.stringify(doc.pick('number', 'string', 'flag')));
@@ -227,7 +243,7 @@
 
   test('data has priority over pick attributes', 2, function() {
     var data = { foo: 'bar' };
-    doc.doAction({ data: data });
+    doc.doAction(data);
 
     strictEqual(this.syncArgs.model, doc);
     equal(this.ajaxSettings.data, JSON.stringify(data));
@@ -242,7 +258,7 @@
 
   test('merge data to be sent', 2, function() {
     var data = { fu: 'baz' };
-    doc.doActionWithData({ data: data });
+    doc.doActionWithData(data);
 
     strictEqual(this.syncArgs.model, doc);
     equal(this.ajaxSettings.data, JSON.stringify(_.extend({ foo: 'bar' }, data)));
@@ -250,7 +266,7 @@
 
   test('data is not stringified for GET methods', 2, function() {
     var data = { foo: 'bar' };
-    doc.doGet({ data: data });
+    doc.doGet(data);
 
     strictEqual(this.syncArgs.model, doc);
     deepEqual(this.ajaxSettings.data, data);
@@ -264,7 +280,7 @@
   });
 
   test('JSON can be emulated', 3, function() {
-    doc.doActionWithData({ emulateJSON: true });
+    doc.doActionWithData(null, { emulateJSON: true });
 
     strictEqual(this.syncArgs.model, doc);
     equal(this.ajaxSettings.contentType, 'application/x-www-form-urlencoded');
@@ -273,7 +289,7 @@
 
   test('HTTP methods can be emulated', 4, function() {
     var data = { foo: 'bar' };
-    doc.doPut({ data: data, emulateHTTP: true, emulateJSON: true });
+    doc.doPut(data, { emulateHTTP: true, emulateJSON: true });
 
     strictEqual(this.syncArgs.model, doc);
     equal(this.ajaxSettings.contentType, 'application/x-www-form-urlencoded');


### PR DESCRIPTION
Work done to complete #10:
- [x] Change parameters for action `perform` methods to take `data` and then `options` (instead of having `data` as a property of the `options` argument)
- [x] Actions setup now fails if property already exists on model for a given action name

As mentioned in a comment on that issue, I was unable to determine a clean and easy method for which the `Backbone.Do(model)` could be avoided, so this will remain as a necessary step for the time being but may be addressed again in the future.
